### PR TITLE
Initialize tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,26 @@
             "email":"lablnet01@gmail.com",
             "homepage": "https://softhub99.com"
         }
-    ],  
+    ],
+    "require": {
+        "php": "^7.1",
+        "ext-mbstring": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "suggest": {
+        "ext-openssl": "This is for the OpenSSL encryption",
+        "ext-sodium": "This is for the Sodium encryption"
+    },
     "autoload": {
         "psr-4": {
-             "Lablnet\\": "src/"
+            "Lablnet\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Lablnet\\Tests\\": "tests/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -3,13 +3,13 @@
 /**
  * This file is the Encryption test.
  *
- * @author   Malik Umer Farooq <lablnet01@gmail.com>
- * @author-profile https://www.facebook.com/malikumerfarooq01/
+ * @author   Peter279k <peter279k@gmail.com>
+ * @author-profile https://peterli.website/
  *
  * For the full copyright and license information, please view the LICENSE
  *  file that was distributed with this source code.
  *
- * @since 3.0.0
+ * @note This file is not a part of Zest Framework.
  *
  * @license MIT
  */
@@ -23,7 +23,7 @@ class EncryptionTest extends TestCase
 {
     public function testEncryptAndDecryptWithOpenSsl()
     {
-        $encryption = new Encryption('openssl', '12345678990-=====-===');
+        $encryption = new Encryption('12345678990-=====-===','openssl');
         $encryptedString = $encryption->encrypt('plain-text');
         $decryptedString = $encryption->decrypt($encryptedString);
 
@@ -34,7 +34,7 @@ class EncryptionTest extends TestCase
 
     public function testEncryptAndDecryptWithSodium()
     {
-        $encryption = new Encryption('sodium', 'euyq74tjfdskjFDSGq74');
+        $encryption = new Encryption('euyq74tjfdskjFDSGq74','sodium');
         $encryptedString = $encryption->encrypt('plain-text');
         $decryptedString = $encryption->decrypt($encryptedString);
 

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is the Encryption test.
+ *
+ * @author   Malik Umer Farooq <lablnet01@gmail.com>
+ * @author-profile https://www.facebook.com/malikumerfarooq01/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ * @since 3.0.0
+ *
+ * @license MIT
+ */
+
+namespace Lablnet\Tests;
+
+use Lablnet\Encryption;
+use PHPUnit\Framework\TestCase;
+
+class EncryptionTest extends TestCase
+{
+    public function testEncryptAndDecryptWithOpenSsl()
+    {
+        $encryption = new Encryption('openssl', '12345678990-=====-===');
+        $encryptedString = $encryption->encrypt('plain-text');
+        $decryptedString = $encryption->decrypt($encryptedString);
+
+        $this->assertStringEndsWith('==', $encryptedString);
+        $this->assertSame(80, strlen($encryptedString));
+        $this->assertSame('plain-text', $decryptedString);
+    }
+
+    public function testEncryptAndDecryptWithSodium()
+    {
+        $encryption = new Encryption('sodium', 'euyq74tjfdskjFDSGq74');
+        $encryptedString = $encryption->encrypt('plain-text');
+        $decryptedString = $encryption->decrypt($encryptedString);
+
+        $this->assertStringEndsWith('==', $encryptedString);
+        $this->assertSame(80, strlen($encryptedString));
+        $this->assertSame('plain-text', $decryptedString);
+    }
+}


### PR DESCRIPTION
# Changed log
- Initialize tests.
- Require the `phpunit/phpunit` package and it defines on`require-dev` block in `composer.json`.
- It should require the `mbstring` extension because this repo uses the related functions.
- The `openssl` and `sodium` extensions are optional extension and they should be mentioned on `suggest` block in `composer.json`.