### PR TITLE
Fix key is same on different Encryption classes

### DIFF
--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -45,8 +45,8 @@ class Encryption
      */
     public function __construct($key, $adapter = null)
     {
-        ($adapter !== null) ? $this->setAdapter($adapter) : $this->setAdapter('openssl');
         $this->setKey($key);
+        ($adapter !== null) ? $this->setAdapter($adapter) : $this->setAdapter('openssl');
     }
 
     /**

--- a/tests/EncryptionTest.php
+++ b/tests/EncryptionTest.php
@@ -22,6 +22,17 @@ use PHPUnit\Framework\TestCase;
 
 class EncryptionTest extends TestCase
 {
+    public function testEncryptAndDecryptOnDifferentKeyWithOpenSsl()
+    {
+        $encryption = new Encryption('12345678990-=====-===', 'openssl');
+        $encryptedString = $encryption->encrypt('plain-text');
+
+        $encryption2 = new Encryption('different_key', 'openssl');
+        $decryptedString = $encryption2->decrypt($encryptedString);
+
+        $this->assertFalse($decryptedString);
+    }
+
     public function testEncryptAndDecryptWithOpenSsl()
     {
         $encryption = new Encryption('12345678990-=====-===', 'openssl');


### PR DESCRIPTION
# Changed log
- Fix this problem mentioned on [issue comment thread](https://github.com/Lablnet/PHP-Encryption/issues/5#issuecomment-590035674).
- I also add related tests to prove this PR should be done for that.