### PR TITLE
Abstract Adapter should be interface

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -16,17 +16,8 @@
 
 namespace Lablnet\Adapter;
 
-abstract class AbstractAdapter
+interface AbstractAdapter
 {
-    /**
-     * Store the secret key.
-     *
-     * @since 3.0.0
-     *
-     * @var string key
-     */
-    protected $key;
-
     /**
      * Encrypt the message.
      *
@@ -36,7 +27,7 @@ abstract class AbstractAdapter
      *
      * @return mixed
      */
-    abstract public function encrypt($data);
+    public function encrypt($data);
 
     /**
      * Decrypt the message.
@@ -47,5 +38,5 @@ abstract class AbstractAdapter
      *
      * @return mixed
      */
-    abstract public function decrypt($token);
+    public function decrypt($token);
 }

--- a/src/Adapter/OpenSslEncryption.php
+++ b/src/Adapter/OpenSslEncryption.php
@@ -18,7 +18,7 @@ namespace Lablnet\Adapter;
 
 use InvalidArgumentException;
 
-class OpenSslEncryption extends AbstractAdapter
+class OpenSslEncryption implements AbstractAdapter
 {
     /**
      * Store the cipher iv.
@@ -28,6 +28,13 @@ class OpenSslEncryption extends AbstractAdapter
      * @var string
      */
     private $iv;
+
+    /**
+     * Store secret key.
+     *
+     * @var string
+     */
+    private $key;
 
     /**
      * Cipher.

--- a/src/Adapter/SodiumEncryption.php
+++ b/src/Adapter/SodiumEncryption.php
@@ -19,8 +19,15 @@ namespace Lablnet\Adapter;
 use Exception;
 use InvalidArgumentException;
 
-class SodiumEncryption extends AbstractAdapter
+class SodiumEncryption implements AbstractAdapter
 {
+    /**
+     * Store secret key.
+     *
+     * @var string
+     */
+    private $key;
+
     /**
      * __Construct.
      *


### PR DESCRIPTION
# Changed log
- The `AbstractAdapter` class should be interface. That is, the `encrypt` and `decrypt` methods should be implemented for classes implement this.